### PR TITLE
added missing privileges to pod webhook

### DIFF
--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -130,7 +130,12 @@ func (d *PodNetbirdInjector) Default(ctx context.Context, obj runtime.Object) er
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"NET_ADMIN"},
+				Privileged: pointer.Bool(true),
+				Add: []corev1.Capability{
+					"NET_ADMIN",
+					"SYS_ADMIN",
+					"SYS_RESOURCE",
+				},
 			},
 		},
 		VolumeMounts: nbSetupKey.Spec.VolumeMounts,


### PR DESCRIPTION
If a pod is started through the webhook it failed because of missing privileges.